### PR TITLE
Add ability to focus on the selected room

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -6,10 +6,12 @@ import RoomSelect from "./RoomSelect";
 import InfoPanel from "./InfoPanel";
 import config from "./config";
 import { Room } from "./config.types";
+import { set } from "ol/transform";
 
 export default function App({ roomId }: { roomId?: string }) {
   const room = config.map.rooms.find((room) => room.id === roomId);
   const [selectedRoom, setSelectedRoom] = useState<Room | undefined>(room);
+  const [focusedRoom, setFocusedRoom] = useState<Room | undefined>(undefined);
 
   const [infoPanelExpanded, setInfoPanelExpanded] = useState(() => {
     return Boolean(
@@ -28,10 +30,28 @@ export default function App({ roomId }: { roomId?: string }) {
     }
   };
 
+  const onRoomSelectedFromMap = (room?: Room) => {
+    setFocusedRoom(undefined);
+    onRoomSelected(room);
+  };
+
+  const onRoomSelectedFromDropdown = (room?: Room) => {
+    setFocusedRoom(room);
+    onRoomSelected(room);
+  };
+
   const onInfoPanelExpandChange = (expanded: boolean) => {
     setInfoPanelExpanded(expanded);
     typeof localStorage !== "undefined" &&
       localStorage.setItem("infoPanelExpanded", expanded ? "true" : "");
+  };
+
+  const onZoomClick = (room: Room) => {
+    setFocusedRoom(room);
+  };
+
+  const onPan = () => {
+    setFocusedRoom(undefined);
   };
 
   return (
@@ -40,13 +60,17 @@ export default function App({ roomId }: { roomId?: string }) {
         className="h-screen w-screen"
         config={config}
         selectedRoom={selectedRoom}
-        onRoomSelected={onRoomSelected}
+        focusedRoom={focusedRoom}
+        onRoomSelected={onRoomSelectedFromMap}
+        onPan={onPan}
       />
-      <RoomSelect config={config} onRoomSelected={onRoomSelected} />
+      <RoomSelect config={config} onRoomSelected={onRoomSelectedFromDropdown} />
       <InfoPanel
         room={selectedRoom}
         expanded={infoPanelExpanded}
+        focusedRoom={focusedRoom}
         onInfoPanelExpandChange={onInfoPanelExpandChange}
+        onZoomClick={onZoomClick}
       />
     </main>
   );

--- a/app/InfoPanel.tsx
+++ b/app/InfoPanel.tsx
@@ -1,4 +1,8 @@
-import { ChevronUpIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
+import {
+  ChevronUpIcon,
+  ChevronDownIcon,
+  ViewfinderCircleIcon,
+} from "@heroicons/react/24/solid";
 import Markdown from "react-markdown";
 import { Room } from "./config.types";
 import { useTranslations } from "next-intl";
@@ -7,20 +11,30 @@ import { dedent } from "./text-utils";
 interface InfoPanelProps {
   room?: Room;
   expanded: boolean;
+  focusedRoom?: Room;
   onInfoPanelExpandChange?: (expanded: boolean) => void;
+  onZoomClick?: (room: Room) => void;
 }
 
 export default function InfoPanel({
   room,
   expanded,
+  focusedRoom,
   onInfoPanelExpandChange,
+  onZoomClick,
 }: InfoPanelProps) {
   let panel = <></>;
   if (room) {
-    const onPanelClick = () => {
+    const handlePanelClick = () => {
       if (room.description) {
         onInfoPanelExpandChange && onInfoPanelExpandChange(!expanded);
       }
+    };
+
+    const handleZoomClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (!onZoomClick) return;
+      e.stopPropagation();
+      onZoomClick(room);
     };
 
     let icon;
@@ -35,13 +49,21 @@ export default function InfoPanel({
     }
 
     panel = (
-      <div className="relative text-left bg-background p-4 pt-6 shadow-top">
+      <div className="relative bg-background p-4 pt-6 text-left shadow-top">
         <header
           className={`${expanded && room.description ? "border-1 border-b border-border pb-2" : ""} ${room.description ? "cursor-pointer" : ""}`}
-          onClick={onPanelClick}
+          onClick={handlePanelClick}
         >
           <p className="absolute left-0 right-0 top-0">{icon}</p>
-          <h1 className="text-xl">{room.label}</h1>
+          <h1 className="text-xl">
+            <button
+              className="mr-2 align-text-bottom"
+              onClick={handleZoomClick}
+            >
+              <ViewfinderCircleIcon className="m-auto size-6" />
+            </button>
+            {room.label}
+          </h1>
           <h2 className="text-secondary-text">{room.aliases?.join(", ")}</h2>
         </header>
         {expanded && room.description && (
@@ -67,7 +89,7 @@ export default function InfoPanel({
 
   return (
     <div className="absolute bottom-0 left-0 right-0 text-right">
-      <div className="inline-block bg-background shadow-xl rounded m-2 border border-border opacity-75 hover:opacity-100">
+      <div className="m-2 inline-block rounded border border-border bg-background opacity-75 shadow-xl hover:opacity-100">
         <a href="/about" className="inline-block p-2">
           {t("about.title")}
         </a>

--- a/app/Map.tsx
+++ b/app/Map.tsx
@@ -14,8 +14,10 @@ import { Room, Config } from "./config.types";
 interface MapProps extends React.HTMLAttributes<HTMLDivElement> {
   config: Config;
   selectedRoom?: Room;
+  focusedRoom?: Room;
   onRoomSelected?: (room?: Room) => void;
   onInfoSelected?: () => void;
+  onPan?: () => void;
 }
 
 async function decodeAllImages(src: string) {
@@ -28,8 +30,10 @@ async function decodeAllImages(src: string) {
 export default function Map({
   config,
   selectedRoom,
+  focusedRoom,
   onRoomSelected,
   onInfoSelected,
+  onPan,
   ...divProps
 }: MapProps) {
   const [mapDiv, setMapDiv] = useState<HTMLDivElement | null>(null);
@@ -142,6 +146,7 @@ export default function Map({
             "map-extent",
             JSON.stringify(map.getView().calculateExtent()),
           );
+        onPan && onPan();
       });
 
       setMap(map);
@@ -196,7 +201,20 @@ export default function Map({
     if (selected != null) {
       setSelectedFeature(selected);
     }
-  }, [map, selectedRoom]);
+
+    const focused = vectorLayer
+      .getSource()!
+      .getFeatures()
+      .find(
+        (f: { get: (arg0: string) => Room }) => f.get("room") === focusedRoom,
+      );
+    if (focused != null) {
+      map.getView().fit(focused.getGeometry().getExtent(), {
+        duration: 100,
+        maxZoom: 3,
+      });
+    }
+  }, [map, selectedRoom, focusedRoom]);
 
   useEffect(() => {
     selectedFeature?.setStyle(selectedStyle);


### PR DESCRIPTION
When selecting a room in the search results, it now pans and zooms to focus on the selected room.

This also adds an icon to the left of the room title in the description bar at the bottom to allow the user to pan and zoom on the selected room.